### PR TITLE
fix pool spec mapping

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -264,7 +264,7 @@ _pool_spec = {
             'ro': False,
         },
         'member_prefixes_v6': {
-            'column': 'po.member_prefixes_v',
+            'column': 'po.member_prefixes_v6',
             'ro': False,
         },
         'name': {


### PR DESCRIPTION
fix pool spec mapping to search for member_prefixes_v6 correctly